### PR TITLE
[Add] 태그 css 스타일링

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -93,14 +93,14 @@ const TestPage = () => {
         <TagInputBox tags={dumyTags} />
       </div>
       <div>
-        <TagButton name="tag1" />
-        <TagButton name="tag2" />
-        <TagButton name="tag3" />
+        <TagButton name="tag1" color="red" />
+        <TagButton name="tag2" color="orenge" />
+        <TagButton name="tag3" color="yellow" />
       </div>
       <div>
-        <Tag name="tag4" color="blue" />
-        <Tag name="tag5" color="gree" />
-        <Tag name="tag6" color="pink" />
+        <Tag name="tag4" color="green" />
+        <Tag name="tag5" color="blue" />
+        <Tag name="tag6" color="purple" />
       </div>
       <div>
         <TaskList tasks={dumyTasks} />

--- a/front/src/styles/Input.module.css
+++ b/front/src/styles/Input.module.css
@@ -41,3 +41,8 @@
   margin-top: 0.3em;
   margin-bottom: 0.8em;
 }
+
+.tagInput {
+  border-radius: 3em;
+  padding: 0.3em 0.8em;
+}

--- a/front/src/styles/Tag.module.css
+++ b/front/src/styles/Tag.module.css
@@ -1,8 +1,14 @@
+@value colors: './common/color.css';
+@value size: './common/size.css';
+@value colorWhite,colorLightGray,tagColorRed,tagColorYellow,tagColorGreen,tagColorBlue,tagColorPurple from colors;
+@value weight-regular from size;
+
 .tag {
   display: inline-block;
   font-size: 1em;
+  font-weight: weight-regular;
   align-items: center;
-  background-color: gray;
+  background-color: colorLightGray;
   padding: 0.3em 0.8em;
   border-radius: 3em;
   transition: width 300ms ease;
@@ -12,12 +18,28 @@
   margin-left: 0.5em;
 }
 
-.blue {
-  color: white;
-  background-color: blue;
+/* tag color */
+.red {
+  background-color: tagColorRed;
 }
 
-.tag:hover span[data-hover="show"] {
+.yellow {
+  background-color: tagColorYellow;
+}
+
+.blue {
+  background-color: tagColorBlue;
+}
+
+.green {
+  background-color: tagColorGreen;
+}
+
+.purple {
+  background-color: tagColorPurple;
+}
+
+.tag:hover span[data-hover='show'] {
   width: 0.8em;
   opacity: 1;
 }

--- a/front/src/styles/common/color.css
+++ b/front/src/styles/common/color.css
@@ -14,3 +14,11 @@
 @value colorSkyblue: #A7BEEE;
 @value colorPurple: #622BFF;
 @value colorDarkPurple: #3900CB;
+
+/* tag 색 */
+@value tagColorRed: #FF98A5;
+@value tagColorOrenge: #FFC8A8;
+@value tagColorYellow: #FEFF84;
+@value tagColorBlue: #ACE8FF;
+@value tagColorGreen: #B9FFBD;
+@value tagColorPurple: #D4B4FF;


### PR DESCRIPTION

<img width="210" alt="스크린샷 2021-05-01 오후 4 30 33" src="https://user-images.githubusercontent.com/80464961/116775393-d54b4780-aa9d-11eb-96dc-50c1f832f9cf.png">

파스텔톤으로 태그 스타일링을 해보았습니다.
(예시 색상이므로 사후 조정해야 할 것으로 보임)
일단 주로 쓰이는 6가지 색깔로 구성해보았는데요! 
나중에 필요한 색이 있다면 추가하면 될 것 같습니다.

<img width="81" alt="스크린샷 2021-05-01 오후 1 02 14" src="https://user-images.githubusercontent.com/80464961/116770368-48dd5c80-aa7e-11eb-98c1-b0524ba09c17.png">

그리고 태그 인풋박스인데요. 글자적으면 잘리더라구요....!
글자에 따라 인풋박스 크기가 잘리지 않을만큼만 옆으로 늘어나면 좋을 거 같습니다!

방금 피그마 디자인 보려고 들어갔는데 권한이 없어서 안 열리네요 ㅠㅠㅠ
보기 권한 주시면 감사하겠습니다~~

close #101 