### PR TITLE
[Add] 투두리스트 체크에 따른 상태변화 css

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -85,7 +85,7 @@ const dumyTags = [
   {
     id: 'j4832843enbhfi2',
     name: '중요',
-    color: 'pink',
+    color: 'red',
   },
 ];
 

--- a/front/src/styles/TaskItem.module.css
+++ b/front/src/styles/TaskItem.module.css
@@ -38,6 +38,18 @@
   display: flex;
 }
 
-#input-check:checked + .content {
-  background-color: blue;
+/* check에 따른 상태변화 */
+.checked {
+  color: colorGray;
+  position: relative;
+}
+
+.checked::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 100%;
+  left: 0;
+  height: 1px;
+  background-color: red;
 }


### PR DESCRIPTION

<img width="317" alt="스크린샷 2021-05-03 오후 7 42 59" src="https://user-images.githubusercontent.com/80464961/116867855-b6d57f80-ac48-11eb-82c1-0709996a251f.png">
<img width="323" alt="스크린샷 2021-05-03 오후 7 43 21" src="https://user-images.githubusercontent.com/80464961/116867860-b89f4300-ac48-11eb-8553-d6fa469de20b.png">

체크를 누르면 내용의 상태가 변합니다.
가로줄 같은 경우 일단 빨간색으로 설정 했는데, 회색 버전도 한 번 시험삼아 캡쳐 해보았습니다.

close #123 
