### PR TITLE
[Feat] 태스크 수정 기능 추가 #215

### DIFF
--- a/front/src/components/QuickAddForm.jsx
+++ b/front/src/components/QuickAddForm.jsx
@@ -37,7 +37,8 @@ const QuickAddForm = ({ toggleTaskFormModal, addTask }) => {
 
   const onDetailClick = () => {
     // QuickAddForm 입력을 TaskModal로 전달하고 초기화
-    toggleTaskFormModal(inputRef.current.value);
+    const task = { content: inputRef.current.value };
+    toggleTaskFormModal('', task);
     inputRef.current.value = '';
   };
 
@@ -59,7 +60,8 @@ const QuickAddForm = ({ toggleTaskFormModal, addTask }) => {
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    toggleTaskFormModal: (quickInput) => dispatch(actionCreators.toggleTaskFormModal(quickInput)),
+    toggleTaskFormModal: (taskId, task) =>
+      dispatch(actionCreators.toggleTaskFormModal(taskId, task)),
     addTask: (task) => dispatch(actionCreators.addTask(task)),
   };
 };

--- a/front/src/components/QuickAddForm.jsx
+++ b/front/src/components/QuickAddForm.jsx
@@ -6,14 +6,14 @@ import Button from './Button';
 import IconButton from './IconButton';
 import Input from './Input';
 import styles from '../styles/QuickAddForm.module.css';
+import accountManager from '../utils/account-manager';
 
 /**
  * Task 내용만 입력하여 Task를 빠르게 추가하는 폼 컴포넌트
  * @param {Fucntion} toggleTaskFormModal - 전역 모달 상태를 변경하여 태스크 폼을 토글하는 함수
  */
 
-const QuickAddForm = ({ toggleTaskFormModal, addTask }) => {
-  const formRef = useRef();
+const QuickAddForm = ({ token, toggleTaskFormModal, addTask }) => {
   const inputRef = useRef();
 
   const onSubmit = (event) => {
@@ -21,17 +21,14 @@ const QuickAddForm = ({ toggleTaskFormModal, addTask }) => {
 
     if (inputRef.current.value === '') return;
 
-    const form = new FormData(formRef.current);
-
-    const task = Array.from(form.keys()).reduce((obj, key) => {
-      const copied = { ...obj };
-      if (!form.get(key)) return {};
-      copied[key] = form.get(key);
-      return copied;
-    }, {});
+    const currentTime = Date.now();
+    const task = {
+      content: inputRef.current.value,
+      periods: { start: currentTime, end: currentTime },
+    };
 
     addTask(task);
-
+    accountManager.addTask(token, task);
     inputRef.current.value = '';
   };
 
@@ -43,7 +40,7 @@ const QuickAddForm = ({ toggleTaskFormModal, addTask }) => {
   };
 
   return (
-    <form ref={formRef} className={styles.form} onSubmit={onSubmit}>
+    <form className={styles.form} onSubmit={onSubmit}>
       <IconButton Icon={FaPlus} styleName="QuickAddForm__icon" onClick={onDetailClick} />
       <Input
         inputRef={inputRef}

--- a/front/src/components/Tag.jsx
+++ b/front/src/components/Tag.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styles from '../styles/Tag.module.css';
+import colorManager from '../utils/color-manager';
 
 /** Created by 오영롱(youngrongoh) on 2021/04/23
  * 태스크의 태그를 나타내는 컴포넌트
@@ -8,11 +9,14 @@ import styles from '../styles/Tag.module.css';
  * @param {ReactElement} props.children - 컴포넌트의 자식 요소
  * @param {string} props.styleName - 스타일링 변화를 줄 때 사용되는 클래스명 문자열
  */
-const Tag = ({ name, color, children, styleName }) => (
-  <div className={`${styles.tag} ${styles[color]} ${styles[styleName]}`}>
-    <span className={styles.name}>{name}</span>
-    {children}
-  </div>
-);
+const Tag = ({ name, color = '', children, styleName }) => {
+  const colorName = color.includes('#') ? colorManager.toName(color) : color;
+  return (
+    <div className={`${styles.tag} ${styles[colorName || '']} ${styles[styleName]}`}>
+      <span className={styles.name}>{name}</span>
+      {children}
+    </div>
+  );
+};
 
 export default Tag;

--- a/front/src/components/TagButton.jsx
+++ b/front/src/components/TagButton.jsx
@@ -10,19 +10,26 @@ import styles from '../styles/TagButton.module.css';
  * @param {text} props.color - 태그 색상을 설정하는 문자열, 5-10가지 종류 색상을 지정해서 사용
  * @param {Function} props.onClick - 태그 색상을 설정하는 문자열, 5-10가지 종류 색상을 지정해서 사용
  */
-const TagButton = ({ tagId, name, color, onClick, onDelete }) => {
-  const onTagClick = (event) => {
+const TagButton = ({ tagId, name, color, isMainTag, onMouseDown, onMouseUp, onDelete }) => {
+  const onTagMouseDown = (event) => {
     if (event.defaultPrevented) return; // delete 버튼이 클릭될 때는 실행하지 않음
 
-    if (onClick instanceof Function) onClick(event);
+    if (onMouseDown instanceof Function) onMouseDown(tagId);
+  };
+
+  const onTagMouseUp = (event) => {
+    if (event.defaultPrevented) return; // delete 버튼이 클릭될 때는 실행하지 않음
+
+    if (onMouseUp instanceof Function) onMouseUp(event);
   };
 
   const onKeyDown = () => {};
 
   return (
     <div
-      className={styles.tag}
-      onClick={onTagClick}
+      className={isMainTag ? styles.main : ''}
+      onMouseDown={onTagMouseDown}
+      onMouseUp={onTagMouseUp}
       onKeyDown={onKeyDown}
       role="button"
       tabIndex="0"

--- a/front/src/components/TagInputBox.jsx
+++ b/front/src/components/TagInputBox.jsx
@@ -28,8 +28,30 @@ const useFlexInputSize = (intialSize) => {
 const TagInputBox = ({ token, tags = [], inputName, validator, placeholder, setTags, tagList }) => {
   const [value, setValue] = useState('');
   const { inputSize, flexInputSize } = useFlexInputSize(0);
+  let isMouseDown = false;
 
-  const onClick = () => {};
+  const onTagMouseDown = (tagId) => {
+    isMouseDown = true;
+    setTimeout(() => {
+      if (isMouseDown) {
+        const updated = tags.map((tag) => {
+          const copied = { ...tag };
+          if (copied.tagId === tagId) {
+            copied.isMainTag = true;
+          } else {
+            copied.isMainTag = false;
+          }
+          return copied;
+        });
+        setTags(updated);
+        isMouseDown = false;
+      }
+    }, 1000);
+  };
+
+  const onTagMouseUp = () => {
+    isMouseDown = false;
+  };
 
   const addTag = async (name) => {
     const isMainTag = tags.length === 0;
@@ -84,7 +106,9 @@ const TagInputBox = ({ token, tags = [], inputName, validator, placeholder, setT
               tagId={tag.tagId}
               name={tag.name || tagList[tag.tagId].name}
               color={tag.color}
-              onClick={onClick}
+              isMainTag={tag.isMainTag}
+              onMouseDown={onTagMouseDown}
+              onMouseUp={onTagMouseUp}
               onDelete={onTagDelete}
             />
           </li>

--- a/front/src/components/TagInputBox.jsx
+++ b/front/src/components/TagInputBox.jsx
@@ -105,7 +105,7 @@ const TagInputBox = ({ token, tags = [], inputName, validator, placeholder, setT
             <TagButton
               tagId={tag.tagId}
               name={tag.name || tagList[tag.tagId].name}
-              color={tag.color}
+              color={tag.color || tagList[tag.tagId].color}
               isMainTag={tag.isMainTag}
               onMouseDown={onTagMouseDown}
               onMouseUp={onTagMouseUp}

--- a/front/src/components/TagInputBox.jsx
+++ b/front/src/components/TagInputBox.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import generateId from '../utils/id-generator';
 import colorManager from '../utils/color-manager';
 import TagButton from './TagButton';
 import styles from '../styles/InputBox.module.css';
 import inputStyles from '../styles/Input.module.css';
+import accountManager from '../utils/account-manager';
 
 const useFlexInputSize = (intialSize) => {
   const [inputSize, setInputSize] = useState(intialSize);
@@ -25,15 +25,17 @@ const useFlexInputSize = (intialSize) => {
  * @param {string} props.placeholder - input의 placeholder 속성 값
  * @param {Function} props.validator - input의 유효성 검사를 수행할 콜백 함수, 반환하는 boolean 값에 따라 상태 변화 여부 결정
  */
-const TagInputBox = ({ tags = [], inputName, validator, placeholder, setTags }) => {
+const TagInputBox = ({ token, tags = [], inputName, validator, placeholder, setTags }) => {
   const [value, setValue] = useState('');
   const { inputSize, flexInputSize } = useFlexInputSize(0);
 
   const onClick = () => {};
 
-  const addTag = (name) => {
-    const tag = { id: generateId(), name, color: colorManager.getRandomHex() };
-    setTags((previous) => [...previous, tag]);
+  const addTag = async (name) => {
+    const isMainTag = tags.length === 0;
+    const tag = { name, color: colorManager.getRandomHex(), isMainTag };
+    const tagId = await accountManager.addTag(token, tag);
+    setTags((previous) => [...previous, { id: tagId, ...tag }]);
   };
 
   const onKeyDown = (event) => {

--- a/front/src/components/TagInputBox.jsx
+++ b/front/src/components/TagInputBox.jsx
@@ -69,8 +69,9 @@ const TagInputBox = ({ token, tags = [], inputName, validator, placeholder, setT
 
   const onTagDelete = (id) => {
     setTags((previous) => {
-      return [...previous].filter((tag) => tag.id !== id);
+      return [...previous].filter((tag) => tag.tagId !== id);
     });
+    accountManager.deleteTag(token, id);
   };
 
   return (

--- a/front/src/components/TagInputBox.jsx
+++ b/front/src/components/TagInputBox.jsx
@@ -25,7 +25,7 @@ const useFlexInputSize = (intialSize) => {
  * @param {string} props.placeholder - input의 placeholder 속성 값
  * @param {Function} props.validator - input의 유효성 검사를 수행할 콜백 함수, 반환하는 boolean 값에 따라 상태 변화 여부 결정
  */
-const TagInputBox = ({ token, tags = [], inputName, validator, placeholder, setTags }) => {
+const TagInputBox = ({ token, tags = [], inputName, validator, placeholder, setTags, tagList }) => {
   const [value, setValue] = useState('');
   const { inputSize, flexInputSize } = useFlexInputSize(0);
 
@@ -35,7 +35,7 @@ const TagInputBox = ({ token, tags = [], inputName, validator, placeholder, setT
     const isMainTag = tags.length === 0;
     const tag = { name, color: colorManager.getRandomHex(), isMainTag };
     const tagId = await accountManager.addTag(token, tag);
-    setTags((previous) => [...previous, { id: tagId, ...tag }]);
+    setTags((previous) => [...previous, { tagId, ...tag }]);
   };
 
   const onKeyDown = (event) => {
@@ -78,10 +78,10 @@ const TagInputBox = ({ token, tags = [], inputName, validator, placeholder, setT
       <span className={styles.ModalNameTag}>태그</span>
       <ul className={styles.list}>
         {tags.map((tag) => (
-          <li key={tag.id} className={styles.tagItem}>
+          <li key={tag.tagId} className={styles.tagItem}>
             <TagButton
-              tagId={tag.id}
-              name={tag.name}
+              tagId={tag.tagId}
+              name={tag.name || tagList[tag.tagId].name}
               color={tag.color}
               onClick={onClick}
               onDelete={onTagDelete}

--- a/front/src/components/TaskForm.jsx
+++ b/front/src/components/TaskForm.jsx
@@ -61,7 +61,7 @@ const TaskForm = ({ addTask, updateTask, toggleTaskFormModal, token, taskId, tas
       content: contentRef.current.value,
       level: Number(priorityRef.current.value),
       periods,
-      tags: tags.length > 0 ? tags : null,
+      tags,
     };
 
     // taskId가 없으면 등록, 있으면 수정

--- a/front/src/components/TaskForm.jsx
+++ b/front/src/components/TaskForm.jsx
@@ -80,6 +80,7 @@ const TaskForm = ({ addTask, updateTask, toggleTaskFormModal, token, taskId, tas
     toggleTaskFormModal();
   };
 
+  const currentTime = Date.now();
   return (
     <form onSubmit={onTaskSubmit} className={styles.form}>
       <div className={styles.header}>
@@ -105,9 +106,9 @@ const TaskForm = ({ addTask, updateTask, toggleTaskFormModal, token, taskId, tas
       <PrioritySelector inputRef={priorityRef} priority={task.level} inputName="level" />
       <PeriodInputBox
         refs={{ startRef, endRef }}
-        periods={task.periods || { start: Date.now(), end: Date.now() + 3600000 }}
+        periods={task.periods || { start: currentTime, end: currentTime }}
       />
-      <TagInputBox tags={tags} inputName="tags" setTags={setTags} />
+      <TagInputBox token={token} tags={tags} inputName="tags" setTags={setTags} />
     </form>
   );
 };

--- a/front/src/components/TaskForm.jsx
+++ b/front/src/components/TaskForm.jsx
@@ -10,7 +10,7 @@ import styles from '../styles/TaskForm.module.css';
 import Input from './Input';
 import accountManager from '../utils/account-manager';
 
-const TaskForm = ({ addTask, updateTask, toggleTaskFormModal, token, taskId, task }) => {
+const TaskForm = ({ addTask, updateTask, toggleTaskFormModal, token, taskId, task, tagList }) => {
   const [tags, setTags] = useState(task.tags || []);
   const contentRef = useRef();
   const priorityRef = useRef();
@@ -108,13 +108,13 @@ const TaskForm = ({ addTask, updateTask, toggleTaskFormModal, token, taskId, tas
         refs={{ startRef, endRef }}
         periods={task.periods || { start: currentTime, end: currentTime }}
       />
-      <TagInputBox token={token} tags={tags} inputName="tags" setTags={setTags} />
+      <TagInputBox tagList={tagList} token={token} tags={tags} inputName="tags" setTags={setTags} />
     </form>
   );
 };
 
-const mapStateToProps = ({ token }) => {
-  return { token };
+const mapStateToProps = ({ token, tags }) => {
+  return { token, tagList: tags };
 };
 
 const mapDispatchToProps = (dispatch) => {

--- a/front/src/components/TaskItem.jsx
+++ b/front/src/components/TaskItem.jsx
@@ -29,6 +29,7 @@ const TaskItem = ({ token, taskId, task, type, updateTask, deleteTask, toggleTas
 
   const onDeleteClick = () => {
     deleteTask(taskId);
+    accountManager.deleteTask(token, taskId);
   };
 
   const onTaskClick = () => {

--- a/front/src/components/TaskItem.jsx
+++ b/front/src/components/TaskItem.jsx
@@ -7,13 +7,16 @@ import IconButton from './IconButton';
 import PriorityIcon from './PriorityIcon';
 import styles from '../styles/TaskItem.module.css';
 import timeparser from '../utils/timestamp-parser';
+import Button from './Button';
+import accountManager from '../utils/account-manager';
 
 /** Created by 오영롱(youngrongoh) on 2021/04/20
  * 전단받은 사용자의 태스크 정보를 투두 형식으로 보여주는 아이템
  * @param {Object} props.task -
  * @param {'basic' | 'daily'} props.type - 태스크 아이템에서 기간(period)에 대한 표시 여부를 결정하는 문자열
  */
-const TaskItem = ({ taskId, task, type, updateTask, deleteTask }) => {
+
+const TaskItem = ({ token, taskId, task, type, updateTask, deleteTask, toggleTaskFormModal }) => {
   const { level, checked, content, periods } = task;
   const isPeriodsRender = periods && type === 'daily';
 
@@ -21,10 +24,15 @@ const TaskItem = ({ taskId, task, type, updateTask, deleteTask }) => {
     const updated = { ...task };
     updated.checked = _checked;
     updateTask(taskId, updated);
+    accountManager.updateTask(token, taskId, updated);
   };
 
   const onDeleteClick = () => {
     deleteTask(taskId);
+  };
+
+  const onTaskClick = () => {
+    toggleTaskFormModal(taskId, task);
   };
 
   return (
@@ -32,7 +40,9 @@ const TaskItem = ({ taskId, task, type, updateTask, deleteTask }) => {
       <div className={styles.elements}>
         <div className={styles.checkcontent}>
           <CheckButton checked={checked} onClick={onCheckClick} />
-          <span className={`${styles.content} ${checked && styles.checked}`}>{content}</span>
+          <Button styleName="taskItem" onClick={onTaskClick}>
+            <span className={`${styles.content} ${checked && styles.checked}`}>{content}</span>
+          </Button>
         </div>
         <div className={styles.iconbuttons}>
           <PriorityIcon level={level} />
@@ -44,11 +54,17 @@ const TaskItem = ({ taskId, task, type, updateTask, deleteTask }) => {
   );
 };
 
+const mapStateToProps = ({ token }) => {
+  return { token };
+};
+
 const mapDispatchToProps = (dispatch) => {
   return {
-    updateTask: (id, task) => dispatch(actionCreators.updateTask({ id, content: task })),
+    updateTask: (taskId, task) => dispatch(actionCreators.updateTask(taskId, task)),
     deleteTask: (id) => dispatch(actionCreators.deleteTask(id)),
+    toggleTaskFormModal: (taskId, task) =>
+      dispatch(actionCreators.toggleTaskFormModal(taskId, task)),
   };
 };
 
-export default connect(undefined, mapDispatchToProps)(TaskItem);
+export default connect(mapStateToProps, mapDispatchToProps)(TaskItem);

--- a/front/src/container/CalendarContainer.jsx
+++ b/front/src/container/CalendarContainer.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Calendar from '../components/Calendar';
 import styles from '../styles/page/Main.module.css';
 
-const CalenderContainer = () => (
+const CalendarContainer = () => (
   <div className={styles.container}>
     <header className={styles.header}>
       <h2 className={styles.title}>Monthly</h2>
@@ -13,4 +13,4 @@ const CalenderContainer = () => (
   </div>
 );
 
-export default CalenderContainer;
+export default CalendarContainer;

--- a/front/src/container/TaskModal.jsx
+++ b/front/src/container/TaskModal.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import Modal from './Modal';
 import TaskForm from '../components/TaskForm';
 
-const TaskModal = ({ content }) => {
+const TaskModal = ({ taskId, task }) => {
   const [display, setDisplay] = useState(true);
 
   const closeModal = () => {
@@ -12,7 +12,7 @@ const TaskModal = ({ content }) => {
   return (
     display && (
       <Modal styleName="taskModal">
-        <TaskForm content={content} onCancel={closeModal} />
+        <TaskForm taskId={taskId} task={task} onCancel={closeModal} />
       </Modal>
     )
   );

--- a/front/src/container/TasksContainer.jsx
+++ b/front/src/container/TasksContainer.jsx
@@ -30,7 +30,7 @@ const TasksContainer = ({ tasks, token, updateTasks }) => {
         <TaskList tasks={tasks} />
       </div>
       <footer className={styles.footer}>
-        <QuickAddForm />
+        <QuickAddForm token={token} />
       </footer>
     </div>
   );

--- a/front/src/container/TasksContainer.jsx
+++ b/front/src/container/TasksContainer.jsx
@@ -6,7 +6,7 @@ import { actionCreators } from '../store/store';
 import styles from '../styles/page/Main.module.css';
 import accountManager from '../utils/account-manager';
 
-const TasksContainer = ({ tasks, token, updateTasks }) => {
+const TasksContainer = ({ tasks, token, updateTasks, getTags }) => {
   useEffect(() => {
     if (!token) return;
     const now = new Date();
@@ -19,7 +19,9 @@ const TasksContainer = ({ tasks, token, updateTasks }) => {
       },
       updateTasks,
     );
-  }, [token, updateTasks]);
+
+    accountManager.getUserTags(token, getTags);
+  }, [token, updateTasks, getTags]);
 
   return (
     <div className={styles.container}>
@@ -43,6 +45,7 @@ const mapStateToProps = ({ tasks, token }) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     updateTasks: (tasks) => dispatch(actionCreators.updateTasks(tasks)),
+    getTags: (tags) => dispatch(actionCreators.getTags(tags)),
   };
 };
 

--- a/front/src/page/Main.jsx
+++ b/front/src/page/Main.jsx
@@ -8,7 +8,7 @@ import Navbar from '../container/Navbar';
 import TaskModal from '../container/TaskModal';
 import ProfileModal from '../components/ProfileModal';
 import TasksContainer from '../container/TasksContainer';
-import CalenderContainer from '../container/CalenderContainer';
+import CalendarContainer from '../container/CalendarContainer';
 
 const Main = ({ isProfileShow, isTaskFormShow, task, taskId, createProfile, pushToken }) => {
   const onLoginSuccess = async ({ tokenObj }) => {
@@ -29,7 +29,7 @@ const Main = ({ isProfileShow, isTaskFormShow, task, taskId, createProfile, push
       <Layout
         Side={() => <Navbar />}
         Left={() => <TasksContainer />}
-        Right={() => <CalenderContainer />}
+        Right={() => <CalendarContainer />}
       >
         {isProfileShow && <ProfileModal />}
         {isTaskFormShow && <TaskModal taskId={taskId} task={task} />}

--- a/front/src/page/Main.jsx
+++ b/front/src/page/Main.jsx
@@ -10,7 +10,7 @@ import ProfileModal from '../components/ProfileModal';
 import TasksContainer from '../container/TasksContainer';
 import CalenderContainer from '../container/CalenderContainer';
 
-const Main = ({ isProfileShow, isTaskFormShow, content, createProfile, pushToken }) => {
+const Main = ({ isProfileShow, isTaskFormShow, task, taskId, createProfile, pushToken }) => {
   const onLoginSuccess = async ({ tokenObj }) => {
     const profile = await accountManager.getUserProfile(tokenObj.id_token);
     createProfile(profile);
@@ -32,7 +32,7 @@ const Main = ({ isProfileShow, isTaskFormShow, content, createProfile, pushToken
         Right={() => <CalenderContainer />}
       >
         {isProfileShow && <ProfileModal />}
-        {isTaskFormShow && <TaskModal content={content} />}
+        {isTaskFormShow && <TaskModal taskId={taskId} task={task} />}
       </Layout>
     </>
   );
@@ -42,7 +42,8 @@ const mapStateToProps = ({ modal: { profile, taskForm } }) => {
   return {
     isProfileShow: profile,
     isTaskFormShow: taskForm.display,
-    content: taskForm.content,
+    task: taskForm.task,
+    taskId: taskForm.taskId,
   };
 };
 

--- a/front/src/reducer/modal.js
+++ b/front/src/reducer/modal.js
@@ -5,14 +5,18 @@ export const modals = {
 
 const initialState = {
   [modals.profile]: false,
-  [modals.taskForm]: { display: false, content: '' },
+  [modals.taskForm]: { display: false, taskId: '', task: {} },
 };
 
 const TOGGLE_MODAL = 'TOGGLE_MODAL';
 const TOGGLE_TASK_FORM_MODAL = 'TOGGLE_TASK_FORM_MODAL';
 
 export const toggleModal = (target) => ({ type: TOGGLE_MODAL, target });
-export const toggleTaskFormModal = (content) => ({ type: TOGGLE_TASK_FORM_MODAL, content });
+export const toggleTaskFormModal = (taskId, task) => ({
+  type: TOGGLE_TASK_FORM_MODAL,
+  taskId,
+  task,
+});
 
 const reducer = (state = initialState, action) => {
   const newState = { ...state };
@@ -23,7 +27,8 @@ const reducer = (state = initialState, action) => {
       break;
     case TOGGLE_TASK_FORM_MODAL:
       newState[modals.taskForm].display = !newState[modals.taskForm].display;
-      newState[modals.taskForm].content = action.content;
+      newState[modals.taskForm].taskId = action.taskId;
+      newState[modals.taskForm].task = action.task;
       break;
     default:
       break;

--- a/front/src/reducer/tags.js
+++ b/front/src/reducer/tags.js
@@ -1,0 +1,34 @@
+const GET_TAGS = 'GET_TAGS';
+const ADD_TAG = 'ADD_TAG';
+const UPDATE_TAG = 'UPDATE_TAG';
+const DELETE_TAG = 'DELETE_TAG';
+
+export const getTags = (tags) => ({ type: GET_TAGS, tags });
+export const addTag = (tag) => ({ type: ADD_TAG, tag });
+export const updateTag = (tagId, tag) => ({ type: UPDATE_TAG, tagId, tag });
+export const deleteTag = (id) => ({ type: DELETE_TAG, id });
+
+const reducer = (state = {}, action) => {
+  let tags = { ...state };
+
+  switch (action.type) {
+    case GET_TAGS:
+      tags = action.tags;
+      break;
+    case ADD_TAG:
+      tags[''] = { ...action.tag };
+      break;
+    case UPDATE_TAG:
+      tags[action.tagId] = action.tag;
+      break;
+    case DELETE_TAG:
+      delete tags[action.id];
+      break;
+    default:
+      break;
+  }
+
+  return tags;
+};
+
+export default reducer;

--- a/front/src/reducer/tags.js
+++ b/front/src/reducer/tags.js
@@ -13,7 +13,11 @@ const reducer = (state = {}, action) => {
 
   switch (action.type) {
     case GET_TAGS:
-      tags = action.tags;
+      tags = action.tags.reduce((obj, tag) => {
+        const copied = { ...obj };
+        copied[tag.tagId] = tag;
+        return copied;
+      }, {});
       break;
     case ADD_TAG:
       tags[''] = { ...action.tag };

--- a/front/src/reducer/tasks.js
+++ b/front/src/reducer/tasks.js
@@ -7,7 +7,7 @@ const DELETE_TASK = 'DELETE_TASK';
 
 export const updateTasks = (tasks) => ({ type: UPDATE_TASKS, tasks });
 export const addTask = (task) => ({ type: ADD_TASK, task });
-export const updateTask = (task) => ({ type: UPDATE_TASK, task });
+export const updateTask = (taskId, task) => ({ type: UPDATE_TASK, taskId, task });
 export const deleteTask = (id) => ({ type: DELETE_TASK, id });
 
 const reducer = (state = {}, action) => {
@@ -21,7 +21,7 @@ const reducer = (state = {}, action) => {
       tasks[generateId()] = { ...action.task, checked: false };
       break;
     case UPDATE_TASK:
-      tasks[action.task.id] = action.task.content;
+      tasks[action.taskId] = action.task;
       break;
     case DELETE_TASK:
       delete tasks[action.id];

--- a/front/src/store/store.js
+++ b/front/src/store/store.js
@@ -3,12 +3,14 @@ import profileReducer, { createProfile, deleteProfile, editProfile } from '../re
 import tasksReducer, { addTask, deleteTask, updateTask, updateTasks } from '../reducer/tasks';
 import modalReducer, { toggleModal, toggleTaskFormModal } from '../reducer/modal';
 import tokenReducer, { pushToken, removeToken } from '../reducer/token';
+import tagsReducer, { getTags, addTag, updateTag, deleteTag } from '../reducer/tags';
 
 const rootReducer = combineReducers({
   profile: profileReducer,
   tasks: tasksReducer,
   modal: modalReducer,
   token: tokenReducer,
+  tags: tagsReducer,
 });
 
 const store = createStore(rootReducer);
@@ -25,6 +27,10 @@ export const actionCreators = {
   pushToken,
   removeToken,
   updateTasks,
+  getTags,
+  addTag,
+  updateTag,
+  deleteTag,
 };
 
 export default store;

--- a/front/src/styles/Button.module.css
+++ b/front/src/styles/Button.module.css
@@ -331,7 +331,12 @@
   color: colorPurple;
 }
 
-.profileModal{
+.profileModal {
   color: colorWhite;
 }
 
+.taskItem,
+.taskItem:hover {
+  background-color: transparent;
+  transform: unset;
+}

--- a/front/src/styles/TagButton.module.css
+++ b/front/src/styles/TagButton.module.css
@@ -1,3 +1,5 @@
+@value colorShadow, colorLightWhite, colorPurple from './common/color.css';
+
 /* Created by 오영롱(youngrongoh) on 2021/04/23 */
 .delete {
   display: inline-block;
@@ -7,4 +9,37 @@
   width: 0;
   opacity: 0;
   transition: 300ms ease;
+}
+
+/* 예시 스타일링 */
+.main {
+  position: relative;
+}
+
+.main:after {
+  content: 'M';
+  position: absolute;
+  top: -0.4em;
+  left: -0.4em;
+  width: 1.7em;
+  height: 1.7em;
+  background-color: colorPurple;
+  color: white;
+  font-weight: bold;
+  font-size: 0.6em;
+  text-align: center;
+  line-height: 1.7em;
+  border-radius: 50%;
+  border: 1px solid colorLightWhite;
+  box-shadow: 0.03em 0.03em 0.3em 0.1em rgba(56, 56, 56, 0.5);
+  animation: fade-in 500ms;
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
 }

--- a/front/src/utils/account-manager.js
+++ b/front/src/utils/account-manager.js
@@ -149,7 +149,7 @@ class AccountManager {
       const copied = { ...taskObj };
 
       if (key === 'tags') {
-        copied[key] = task.tags.map((tag) => ({ tagId: tag.id, isMainTag: tag.isMainTag }));
+        copied[key] = task.tags.map((tag) => ({ tagId: tag.tagId, isMainTag: tag.isMainTag }));
         return copied;
       }
 
@@ -182,6 +182,11 @@ class AccountManager {
     // task에 존재하는 값만 객체로 만듦
     const data = Object.keys(task).reduce((taskObj, key) => {
       const copied = { ...taskObj };
+
+      if (key === 'tags') {
+        copied[key] = task.tags.map((tag) => ({ tagId: tag.tagId, isMainTag: tag.isMainTag }));
+        return copied;
+      }
 
       // 서버에서 사용하는 필드명으로 변환하고 값 매칭
       if (task[key]) copied[matchingKeys[key]] = task[key];
@@ -231,6 +236,16 @@ class AccountManager {
     });
 
     return data.data.tag.tagId;
+  };
+
+  deleteTag = async (token, tagId) => {
+    const url = `${process.env.REACT_APP_SERVER_URL}/api/v1/tags/${tagId}`;
+
+    await axios({
+      method: 'delete',
+      url,
+      headers: { Authorization: token },
+    });
   };
 }
 

--- a/front/src/utils/account-manager.js
+++ b/front/src/utils/account-manager.js
@@ -148,16 +148,24 @@ class AccountManager {
     const data = Object.keys(task).reduce((taskObj, key) => {
       const copied = { ...taskObj };
 
+      if (key === 'tags') {
+        copied[key] = task.tags.map((tag) => ({ tagId: tag.id, isMainTag: tag.isMainTag }));
+        return copied;
+      }
+
       if (task[key]) copied[matchingKeys[key]] = task[key];
       return copied;
     }, {});
 
-    await axios({
+    const response = await axios({
       method: 'post',
       url,
       headers: { Authorization: token },
       data,
     });
+
+    // 추후에 서버에서 태스크 id 받아와서 반환하는 것으로 변경
+    return response.data.msg;
   };
 
   updateTask = async (token, taskId, task) => {
@@ -186,6 +194,19 @@ class AccountManager {
       headers: { Authorization: token },
       data,
     });
+  };
+
+  addTag = async (token, tag) => {
+    const url = `${process.env.REACT_APP_SERVER_URL}/api/v1/tags`;
+
+    const { data } = await axios({
+      method: 'post',
+      url,
+      headers: { Authorization: token },
+      data: tag,
+    });
+
+    return data.data.tag.tagId;
   };
 }
 

--- a/front/src/utils/account-manager.js
+++ b/front/src/utils/account-manager.js
@@ -196,6 +196,16 @@ class AccountManager {
     });
   };
 
+  deleteTask = async (token, taskId) => {
+    const url = `${process.env.REACT_APP_SERVER_URL}/api/v1/tasks/${taskId}`;
+
+    await axios({
+      method: 'delete',
+      url,
+      headers: { Authorization: token },
+    });
+  };
+
   addTag = async (token, tag) => {
     const url = `${process.env.REACT_APP_SERVER_URL}/api/v1/tags`;
 

--- a/front/src/utils/account-manager.js
+++ b/front/src/utils/account-manager.js
@@ -99,7 +99,6 @@ class AccountManager {
       if (key) copied[key] = time[key];
       return copied;
     }, {});
-    console.log(params);
 
     let tasks;
     try {
@@ -152,10 +151,37 @@ class AccountManager {
       if (task[key]) copied[matchingKeys[key]] = task[key];
       return copied;
     }, {});
-    console.log(data);
 
     await axios({
       method: 'post',
+      url,
+      headers: { Authorization: token },
+      data,
+    });
+  };
+
+  updateTask = async (token, taskId, task) => {
+    const url = `${process.env.REACT_APP_SERVER_URL}/api/v1/tasks/${taskId}`;
+
+    const matchingKeys = {
+      level: 'important',
+      tags: 'tags',
+      content: 'contents',
+      periods: 'period',
+      checked: 'checked',
+    };
+
+    // task에 존재하는 값만 객체로 만듦
+    const data = Object.keys(task).reduce((taskObj, key) => {
+      const copied = { ...taskObj };
+
+      // 서버에서 사용하는 필드명으로 변환하고 값 매칭
+      if (task[key]) copied[matchingKeys[key]] = task[key];
+      return copied;
+    }, {});
+
+    await axios({
+      method: 'patch',
       url,
       headers: { Authorization: token },
       data,

--- a/front/src/utils/account-manager.js
+++ b/front/src/utils/account-manager.js
@@ -206,6 +206,20 @@ class AccountManager {
     });
   };
 
+  getUserTags = async (token, handleTags) => {
+    const url = `${process.env.REACT_APP_SERVER_URL}/api/v1/tags`;
+
+    const { data } = await axios({
+      method: 'get',
+      url,
+      headers: { Authorization: token },
+    });
+
+    const { tags } = data.data;
+
+    if (handleTags instanceof Function) handleTags(tags);
+  };
+
   addTag = async (token, tag) => {
     const url = `${process.env.REACT_APP_SERVER_URL}/api/v1/tags`;
 


### PR DESCRIPTION
- 태스크 내용 클릭하면 수정 모달 표시
- account manager에 태스크 수정 요청 메서드 추가
- 수정 완료하면 전역상태에 등록, 서버에 수정 요청
close #215 

close #161 CalendarContainer 이름 오타 수정
close #212 [Fix] 테스크 등록할 때 작성 날짜로 기간 기본값 지정
close #217 [Feat] 태그 추가 기능 바인딩
close #220 [Feat] 테스크 삭제 바인딩
close #219  [Feat] 태그 리듀서 상태관리 추가, [Feat] 태스크폼에서 태그 아이디에 따라 이름 매칭
close #218 [Feat] 태스크에 등록된 태그 삭제 기능 추가
close #227 #144  [Feat] 메인태그 변경 기능 추가
1초 이상 태그를 클릭하고 있으면 메인태그로 지정
![메인태그 변경](https://user-images.githubusercontent.com/64844815/118619843-e915de00-b7ff-11eb-8698-8050c3f93bb3.gif)
[Feat] 태그 색상 표시
![태그색상 표시](https://user-images.githubusercontent.com/64844815/118623578-5aa35b80-b803-11eb-9eea-3d42cbec3192.png)
