### PR TITLE
[Fix] 태스크컨테이너 월 표기 문제 수정 #256

### DIFF
--- a/front/src/container/TasksContainer.jsx
+++ b/front/src/container/TasksContainer.jsx
@@ -52,7 +52,7 @@ const TasksContainer = ({ tasks, token, updateTasks, getTags, toggleDetailModal,
     const render = Object.keys(categorized).map((day) => {
       const dateObj = timeparser.categorize(day);
 
-      const month = timeparser.parseMonthIndex(dateObj.month, 'eng');
+      const month = timeparser.parseMonthIndex(dateObj.month - 1, 'eng');
       const { date } = dateObj;
 
       return (


### PR DESCRIPTION
- 5월이 Jun으로 표시되던 것을 May로 표기
<img src="https://user-images.githubusercontent.com/64844815/119593516-115f9700-be15-11eb-9bfd-7a06d5f6c919.png" width="300" alt="변경캡쳐">

close #256 